### PR TITLE
chore: update Dockerfile to retrieve block number dynamically when st…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,4 +52,4 @@ EXPOSE 4337
 
 # start 
 ENV INFURA_API_KEY=""
-CMD ["sh", "-c", "./scripts/run-local-instance.sh -f -r https://sepolia.infura.io/v3/${INFURA_API_KEY} -b 7065442"]
+CMD ["sh", "-c", "LATEST_BLOCK=$(cast block-number --rpc-url https://sepolia.infura.io/v3/${INFURA_API_KEY}) && echo \"Latest block fetched: $LATEST_BLOCK\" && ./scripts/run-local-instance.sh -f -r https://sepolia.infura.io/v3/${INFURA_API_KEY} -b $LATEST_BLOCK"]


### PR DESCRIPTION
## Motivation for Change
Blockchain was being started on a fixed block, which made it harder to run a block explorer.

## How Did I Implement It?
I updated the Dockerfile to execute a cast command to retrieve the latest block.

## Side Effects
None

---

**Related Issue(s)**
- Fixes #2 

**Checklist:**
- [ ] I have performed a semantic version bump
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
